### PR TITLE
Set introduction.adoc as start page to fix 404 error

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -2,5 +2,6 @@ name: mirket-guide
 title: Mirket Kılavuzu
 version: v4.8.x
 display_version: v4.8.x
+start_page: ROOT:introduction.adoc
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
MIRKET-662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Introduced a new starting page for the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->